### PR TITLE
changed to array.objectAt(index) instead of content[index]

### DIFF
--- a/addon/components/select-list.js
+++ b/addon/components/select-list.js
@@ -37,7 +37,7 @@ export default Ember.Component.extend({
     const hasPrompt = !!this.get('prompt');
     const contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex;
 
-    const selection = content[contentIndex];
+    const selection = content.objectAt(contentIndex);
 
     const value = this.attrs.optionValuePath ? Ember.get(selection, this.get('optionValuePath')) : selection;
 


### PR DESCRIPTION
changed array reference from content[contentIndex] to content.objectAt(contentIndex) because the former was returning me undefined in certain instances.
