### PR TITLE
Referencing the correct action name

### DIFF
--- a/tests/dummy/app/templates/strings.hbs
+++ b/tests/dummy/app/templates/strings.hbs
@@ -26,7 +26,7 @@
   <p>Setting the value from the controller still works as well...</p>
   <p>
     {{#each model as |item|}}
-      <button {{action 'setSelection' item}}>Set to {{item}}</button>
+      <button {{action 'setTwoWayValue' item}}>Set to {{item}}</button>
     {{/each}}
   </p>
 </section>


### PR DESCRIPTION
This fixes the demo page when clicking the second set of buttons on the "string" demo page.
